### PR TITLE
Fix lovable plugin source path to use explicit relative path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "lovable",
-      "source": "plugins/lovable/",
+      "source": "./plugins/lovable/",
       "description": "Claude Code integration for Lovable.dev projects. Provides commands, skills, and context for working with Lovable projects via two-way GitHub sync, with integrations with Lovable Cloud's native Edge Functions, database migrations, and backend deployments. Now with Project Structure Map for faster navigation!",
       "version": "1.7.0",
       "author": {


### PR DESCRIPTION
**Summary**
Updates the source path for the lovable plugin in .claude-plugin/marketplace.json from "plugins/lovable/" to "./plugins/lovable/" to use an explicit relative path reference.
What Changed
File: .claude-plugin/marketplace.json
The source field for the lovable plugin entry was updated:

Before: `"source": "plugins/lovable/"`
After: `"source": "./plugins/lovable/"`

**Why**
The addition of ./ makes the path explicitly relative to the current directory, rather than relying on implicit resolution. This is a more conventional and reliable way to reference relative paths, as some path resolution logic may interpret a bare path like plugins/lovable/ differently depending on the working directory or runtime context. Using ./ removes this ambiguity and ensures the plugin is always resolved relative to the location of the config file.
```
  ⎿  Error: Failed to parse marketplace file at ~/.claude/plugins/marketplaces/10K-Digital-lovable-claude-code/.claude-plugin/marketplace.json: Invalid schema:
     ~/.claude/plugins/marketplaces/10K-Digital-lovable-claude-code/.claude-plugin/marketplace.json plugins.0.source: Invalid input
```

**Impact**

No functional changes to the plugin itself
No changes to plugin behavior, version, or metadata
Minimal risk — this is a config-only, one-line change



