### PR TITLE
Add TanStack Start (SSR) architecture support (v1.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lovable",
       "source": "plugins/lovable/",
       "description": "Claude Code integration for Lovable.dev projects. Provides commands, skills, and context for working with Lovable projects via two-way GitHub sync, with integrations with Lovable Cloud's native Edge Functions, database migrations, and backend deployments. Now with Lovable MCP support for faster automated deployments!",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "author": {
         "name": "Felipe Matos from 10K Digital"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 All notable changes to the Lovable Claude Code plugin will be documented in this file.
 
+## [1.8.1] - 2026-06-09
+
+### Added
+
+#### TanStack Start (SSR) Architecture Support
+
+**Problem**: Lovable launched TanStack Start as the default for all new projects (post-April 2026), replacing the Vite SPA architecture. New projects use SSR, file-based routing (`app/routes/`), and TanStack server functions — a fundamentally different structure from legacy projects.
+
+**Solution**: Update plugin to detect and support both architectures, while remaining fully backward-compatible with all existing Vite SPA projects.
+
+**Key architectural differences handled:**
+
+| Feature | Vite SPA (legacy) | TanStack Start (new) |
+|---------|-------------------|----------------------|
+| Config file | `vite.config.ts` | `app.config.ts` |
+| Source directory | `src/` | `app/` |
+| Routing | React Router in `src/App.tsx` | File-based in `app/routes/` |
+| Rendering | Client-side only | Server-side (SSR) |
+| Server logic | Only via Supabase Edge Functions | Also via TanStack server functions (`*.server.ts`) |
+| Server functions deploy | Via Lovable prompt | Auto via GitHub sync |
+
+**Critical distinction for Claude:** TanStack server functions (`app/**/*.server.ts`) are **not** Supabase Edge Functions. They auto-deploy when pushed to GitHub and never need a Lovable deployment prompt. Only `supabase/functions/` still requires manual deployment via Lovable.
+
+#### Files Updated
+
+- `plugins/lovable/skills/lovable/SKILL.md`
+  - Added "Project Architecture Types" section with detection rules
+  - Separated "What Syncs Automatically" into Vite SPA and TanStack Start sections
+  - Updated "File Structure Reference" to document both architectures
+  - Clarified that TanStack server functions auto-deploy (no Lovable prompt needed)
+
+- `plugins/lovable/skills/lovable/references/codebase-map.md`
+  - Added Step 0: Architecture detection (`app.config.ts` vs `vite.config.ts`)
+  - Added TanStack Start directory scanning (`app/`, `app/routes/`)
+  - Added TanStack Start key files table (`__root.tsx`, `*.server.ts`, `app.config.ts`)
+  - Updated routing detection to include TanStack file-based routing conventions
+  - Added separate map templates for Vite SPA and TanStack Start projects
+
+- `plugins/lovable/skills/lovable/references/CLAUDE-template.md`
+  - Added `Architecture` field to Project Overview
+  - Added dual-architecture Project Structure Map templates (Vite SPA and TanStack Start)
+  - Added architecture-aware Workflow Rules with inline comments for conditional use
+
+- `plugins/lovable/commands/init-lovable.md`
+  - Updated scan step (Step 2) to detect architecture type first
+  - Made source file scanning conditional on detected architecture
+  - Updated Question 8.5 (map generation) to use architecture-specific scanning
+  - Updated CLAUDE.md template to include Architecture field and conditional workflow rules
+
+### Changed
+
+- `plugins/lovable/plugin.json`: Version 1.8.0 → 1.8.1
+- `.claude-plugin/marketplace.json`: Version 1.8.0 → 1.8.1
+
+### Backward Compatibility
+
+**No action required for existing users.** All Vite SPA projects continue to work exactly as before. The plugin detects the architecture automatically and applies the appropriate rules.
+
+- Old projects (Vite SPA) → plugin behaves identically to v1.8.0
+- New projects (TanStack Start) → plugin now correctly understands the structure
+
 ## [1.8.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Stop copy-pasting between Lovable and Claude. Stop wrestling with two-way sync. 
 ### **What You Get:**
 
 ✨ **Edit Lovable projects right in your IDE** with all of Claude Code's power
+🏗️ **Dual-architecture support** - works with both Vite SPA and TanStack Start (SSR) projects (NEW in v1.8.1!)
 🔌 **Lovable MCP integration** - deploy via API instead of browser (NEW in v1.8.0!)
 🗺️ **Project Structure Map** - Claude navigates your codebase faster (NEW in v1.7.0!)
 ⚡ **Auto-push to GitHub** - automatic commit and push after every task
@@ -340,11 +341,28 @@ Plus: No more mistakes from copy-paste errors. No more forgotten secrets. No mor
 
 ## **What Gets Synced Automatically**
 
+> **Note:** Lovable now supports two architectures. New projects (post-April 2026) use **TanStack Start (SSR)**; older projects use **Vite SPA**. The plugin detects this automatically.
+
+### Vite SPA projects (`vite.config.ts`)
+
 | What | Auto-Syncs | Next Step |
 |------|-----------|-----------|
-| React components | ✅ Yes | Just push to GitHub |
+| React components (`src/`) | ✅ Yes | Just push to GitHub |
 | Styling/CSS | ✅ Yes | Just push to GitHub |
-| Edge Function code | ⚠️ Partially | Also run `/lovable:deploy-edge` |
+| Supabase Edge Function code | ⚠️ Partially | Also run `/lovable:deploy-edge` |
+| Database migrations | ⚠️ Partially | Also run `/lovable:apply-migration` |
+| New tables | ❌ No | Use Lovable Cloud UI |
+| RLS policies | ❌ No | Use Lovable Cloud UI |
+| Secrets | ❌ No | Use Lovable Cloud UI |
+
+### TanStack Start projects (`app.config.ts`)
+
+| What | Auto-Syncs | Next Step |
+|------|-----------|-----------|
+| React components (`app/`) | ✅ Yes | Just push to GitHub |
+| TanStack server functions (`*.server.ts`) | ✅ Yes | Just push to GitHub — no deploy prompt needed! |
+| Styling/CSS | ✅ Yes | Just push to GitHub |
+| Supabase Edge Function code | ⚠️ Partially | Also run `/lovable:deploy-edge` |
 | Database migrations | ⚠️ Partially | Also run `/lovable:apply-migration` |
 | New tables | ❌ No | Use Lovable Cloud UI |
 | RLS policies | ❌ No | Use Lovable Cloud UI |
@@ -430,7 +448,19 @@ Edit `CLAUDE.md` to customize anything—Claude Code reads and respects your con
 
 ## **Version History**
 
-**v1.7.0** (Latest) ⭐
+**v1.8.1** (Latest) ⭐
+- **TanStack Start (SSR) support** - plugin now understands Lovable's new architecture
+  - Auto-detects project type: Vite SPA (`vite.config.ts`) vs TanStack Start (`app.config.ts`)
+  - Knows that TanStack server functions (`*.server.ts`) auto-deploy — no Lovable prompt needed
+  - Separate structure maps, workflow rules, and scanning for each architecture
+  - Fully backward-compatible: Vite SPA projects unaffected
+
+**v1.8.0**
+- **Lovable MCP integration** - deploy via API instead of browser (3-5x faster, no Chrome extension)
+  - New `/lovable:connect-mcp` command for guided MCP setup
+  - 3-tier priority: MCP → browser automation → manual prompt
+
+**v1.7.0**
 - **Project Structure Map** - Claude navigates your codebase faster!
   - New `/lovable:map` command for generating/updating maps
   - Integrated into `/lovable:init` (optional question)

--- a/plugins/lovable/commands/init-lovable.md
+++ b/plugins/lovable/commands/init-lovable.md
@@ -11,15 +11,22 @@ Set up Claude Code to work with this Lovable.dev project.
 1. **Read the lovable skill** for full context on integration patterns.
 
 2. **Scan the repository** to understand structure:
-   - Check for `supabase/` folder
-   - List Edge Functions in `supabase/functions/`
-   - List migrations in `supabase/migrations/`
-   - Check `src/integrations/supabase/client.ts` for config
+
+   **a. Detect project architecture** (check root directory first):
+   - `app.config.ts` present → **TanStack Start** (new, SSR, post-April 2026)
+   - `vite.config.ts` present → **Vite SPA** (legacy, CSR, pre-April 2026)
+   - Record this for use throughout initialization and in the generated CLAUDE.md
+
+   **b. Scan source files based on architecture:**
+   - *Vite SPA*: Check `src/` folder, `src/App.tsx`, `src/integrations/supabase/client.ts`
+   - *TanStack Start*: Check `app/` folder, `app/routes/`, `app/integrations/supabase/client.ts`
+   - *Both*: Check for `supabase/` folder, list Edge Functions in `supabase/functions/`, list migrations in `supabase/migrations/`
    - Read `package.json` for project name
-   - Scan for secrets using secret-detection skill:
-     - `supabase/functions/**/*.ts` for `Deno.env.get("SECRET_NAME")`
-     - `.env.example`, `.env.template` for KEY=value patterns
-     - Context-based detection (OpenAI, Stripe, Resend, Twilio, etc.)
+
+   **c. Scan for secrets:**
+   - `supabase/functions/**/*.ts` for `Deno.env.get("SECRET_NAME")`
+   - `.env.example`, `.env.template` for KEY=value patterns
+   - Context-based detection (OpenAI, Stripe, Resend, Twilio, etc.)
 
 3. **Ask questions ONE at a time** using the ask_user tool:
 
@@ -130,12 +137,13 @@ Default: yes (recommended)
 ```
 
 **If yes:** Use the codebase-map reference (`skills/lovable/references/codebase-map.md`) to:
-1. Scan directory structure (src/, supabase/, etc.)
-2. Count components, pages, hooks, functions
-3. Detect component organization pattern (flat, feature-based, atomic)
-4. Identify key files (App.tsx, utils.ts, supabase client)
-5. Detect state management pattern
-6. Generate the map section for CLAUDE.md
+1. Use the already-detected architecture (Vite SPA vs TanStack Start) to know which directories to scan
+2. Scan directory structure (`src/` or `app/` depending on architecture, plus `supabase/`)
+3. Count components, pages/routes, hooks, functions
+4. Detect component organization pattern (flat, feature-based, atomic)
+5. Identify key files (App.tsx or `app/routes/__root.tsx`, utils.ts, supabase client)
+6. Detect state management pattern
+7. Generate the map section for CLAUDE.md using the correct template for the architecture
 
 **If no:** Skip map generation, don't include the Project Structure Map section in CLAUDE.md.
 
@@ -294,21 +302,43 @@ This is required for browser automation.
 - **Lovable Project URL**: [if provided]
 - **GitHub**: [user input]
 - **Backend**: [Lovable Cloud / Own Supabase]
+- **Architecture**: [Vite SPA (CSR) / TanStack Start (SSR)]
 
 ## Workflow Rules
 
+[IF VITE SPA - vite.config.ts detected]
 ### ✅ Safe to edit and push to `main`:
-- All `src/` files
-- Config files
-- Edge Function code (deployment needs Lovable)
+- All `src/` files (components, pages, hooks, utils)
+- Config files (`vite.config.ts`, `tailwind.config.js`)
+- Edge Function code in `supabase/functions/` (deployment needs Lovable)
+- Migration files in `supabase/migrations/` (apply needs Lovable)
 
 ### ⚠️ Requires Lovable prompt after edit:
 - Edge Functions → `"Deploy the [name] edge function"`
-- Migrations → `"Apply pending migrations"`
+- Migrations → `"Apply pending Supabase migrations"`
 
 ### ❌ Must use Lovable:
 - Create tables, RLS, storage buckets
 - Add secrets (Cloud UI)
+- Deploy Supabase Edge Functions
+
+[IF TANSTACK START - app.config.ts detected]
+### ✅ Safe to edit and push to `main`:
+- All `app/` files (routes, components, lib, integrations)
+- TanStack server functions (`app/**/*.server.ts`) — auto-deploy, no Lovable prompt needed
+- Config files (`app.config.ts`, `tailwind.config.js`)
+- Supabase Edge Function code in `supabase/functions/` (deployment still needs Lovable)
+- Migration files in `supabase/migrations/` (apply needs Lovable)
+
+### ⚠️ Requires Lovable prompt after edit:
+- Supabase Edge Functions → `"Deploy the [name] edge function"`
+- Migrations → `"Apply pending Supabase migrations"`
+- Note: TanStack server functions (`*.server.ts`) are NOT the same as Supabase Edge Functions — they auto-deploy via GitHub
+
+### ❌ Must use Lovable:
+- Create tables, RLS, storage buckets
+- Add secrets (Cloud UI)
+- Deploy Supabase Edge Functions
 
 ## Secrets
 

--- a/plugins/lovable/plugin.json
+++ b/plugins/lovable/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lovable",
   "description": "Claude Code integration for Lovable.dev projects. Provides commands, skills, and context for working with Lovable projects via two-way GitHub sync, with integrations with Lovable Cloud's native Edge Functions, database migrations, and backend deployments. Now with Lovable MCP support for faster automated deployments!",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Felipe Matos from 10K Digital"
   },

--- a/plugins/lovable/skills/lovable/SKILL.md
+++ b/plugins/lovable/skills/lovable/SKILL.md
@@ -25,23 +25,35 @@ Activate when:
 - User asks about Lovable Cloud or backend deployment
 - Project appears to be a Lovable project (React + Supabase structure)
 
-## Core Concept
+## Project Architecture Types
 
-Lovable uses **two-way GitHub sync** on the `main` branch only:
-- Frontend code syncs automatically
-- Backend operations (Edge Functions, migrations, RLS) require Lovable prompts
+Lovable supports two architectures. **Always detect which one you're working with** before giving advice.
 
-## What Syncs Automatically (GitHub → Lovable)
+### Detecting Architecture
+
+Check the root directory of the user's project:
+- `app.config.ts` present → **TanStack Start** (new, SSR — post-April 2026)
+- `vite.config.ts` present → **Vite SPA** (legacy, CSR — pre-April 2026)
+
+Both are fully supported. Old projects remain on Vite and receive no forced migration.
+
+---
+
+## Vite SPA Architecture (Legacy)
+
+Projects created before April 2026. Client-side rendering only.
+
+### What Syncs Automatically (Vite SPA)
 
 ✅ Edit freely and push to `main`:
 - `src/` - All React components, pages, hooks, utils
 - `public/` - Static assets
-- Config files - vite.config.ts, tailwind.config.js, tsconfig.json
+- Config files - `vite.config.ts`, `tailwind.config.js`, `tsconfig.json`
 - `package.json` - Dependencies
 - `supabase/functions/*/index.ts` - Edge Function **code** (not deployment)
 - `supabase/migrations/*.sql` - Migration **files** (not application)
 
-## What Requires Lovable Deployment
+### What Requires Lovable Deployment (Vite SPA)
 
 ⚠️ After editing, provide Lovable prompt:
 
@@ -54,6 +66,76 @@ Lovable uses **two-way GitHub sync** on the `main` branch only:
 | RLS policy | `"Enable RLS on [table] allowing [who] to [what]"` |
 | Storage bucket | `"Create a [public/private] bucket called [name]"` |
 | Secret/env var | Manual: Cloud → Secrets → Add |
+
+---
+
+## TanStack Start Architecture (New Projects)
+
+Projects created after April 2026. Full server-side rendering (SSR) via TanStack Start.
+
+### Key Differences from Vite SPA
+
+- Routes are **file-based** in `app/routes/` (not React Router in `src/App.tsx`)
+- Config file is `app.config.ts` (not `vite.config.ts`)
+- **Server functions** (`createServerFn`) let server-side logic live directly in component files — no edge function needed for simple server logic
+- Files named `*.server.ts` are server-only and never sent to the browser
+- Pages are rendered as complete HTML on the server before reaching the browser
+
+### What Syncs Automatically (TanStack Start)
+
+✅ Edit freely and push to `main`:
+- `app/` - All routes, components, server functions, layouts
+- `app/routes/` - File-based route pages
+- `public/` - Static assets
+- `app.config.ts`, `tailwind.config.js`, `tsconfig.json` - Config files
+- `package.json` - Dependencies
+- `app/**/*.server.ts` - TanStack server functions (**auto-deploys, no Lovable prompt needed**)
+- `supabase/functions/*/index.ts` - Supabase Edge Function **code** (not deployment)
+- `supabase/migrations/*.sql` - Migration **files** (not application)
+
+### What Requires Lovable Deployment (TanStack Start)
+
+⚠️ After editing, provide Lovable prompt:
+
+| Change Type | Lovable Prompt |
+|-------------|----------------|
+| Supabase Edge Function code | `"Deploy the [name] edge function"` |
+| All Supabase Edge Functions | `"Deploy all edge functions"` |
+| New migration file | `"Apply pending Supabase migrations"` |
+| New table needed | `"Create a [name] table with columns: [list]"` |
+| RLS policy | `"Enable RLS on [table] allowing [who] to [what]"` |
+| Storage bucket | `"Create a [public/private] bucket called [name]"` |
+| Secret/env var | Manual: Cloud → Secrets → Add |
+
+> **Note:** TanStack server functions (`createServerFn`) are **not** Supabase Edge Functions. They live in `app/` and deploy automatically via GitHub sync — no Lovable prompt needed. Only `supabase/functions/` requires manual deployment.
+
+### TanStack Start File Structure
+
+```
+project/
+├── app/                          # ✅ Safe - auto-syncs
+│   ├── routes/                   # File-based routing
+│   │   ├── __root.tsx            # Root layout
+│   │   ├── index.tsx             # Home page (/)
+│   │   └── [route].tsx           # Other pages
+│   ├── components/               # Shared UI components
+│   ├── lib/                      # Utilities and helpers
+│   └── *.server.ts               # ✅ Server functions (auto-deploy)
+├── app.config.ts                 # TanStack Start config
+├── public/                       # Static assets
+├── supabase/
+│   ├── functions/                # ✅ Edit code, ⚠️ needs deploy
+│   └── migrations/               # ✅ Create files, ⚠️ needs apply
+└── CLAUDE.md                     # Project context
+```
+
+---
+
+## Core Concept (Both Architectures)
+
+Lovable uses **two-way GitHub sync** on the `main` branch only:
+- Frontend and server-side code (including TanStack server functions) sync automatically
+- Supabase Edge Functions and database migrations require Lovable prompts after code changes
 
 ## Response Format
 
@@ -71,6 +153,8 @@ For destructive operations, add:
 
 ## File Structure Reference
 
+### Vite SPA (Legacy — `vite.config.ts` present)
+
 ```
 project/
 ├── src/                          # ✅ Safe - auto-syncs
@@ -86,6 +170,32 @@ project/
 │   │   └── [function-name]/
 │   │       └── index.ts
 │   ├── migrations/               # ✅ Create files, ⚠️ needs apply
+│   │   └── YYYYMMDDHHMMSS_*.sql
+│   └── config.toml               # ⚠️ Lovable Cloud manages
+├── .env                          # Local only - Lovable ignores
+└── CLAUDE.md                     # Project context
+```
+
+### TanStack Start (New — `app.config.ts` present)
+
+```
+project/
+├── app/                          # ✅ Safe - auto-syncs
+│   ├── routes/                   # File-based routing
+│   │   ├── __root.tsx            # Root layout
+│   │   ├── index.tsx             # Home route (/)
+│   │   └── [name].tsx            # Named routes
+│   ├── components/               # Shared components
+│   ├── lib/                      # Utilities
+│   ├── integrations/supabase/    # Supabase client + types
+│   └── *.server.ts               # ✅ Server functions (auto-deploy, no prompt needed)
+├── app.config.ts                 # TanStack Start config
+├── public/                       # Static assets
+├── supabase/
+│   ├── functions/                # ✅ Edit code, ⚠️ needs deploy via Lovable
+│   │   └── [function-name]/
+│   │       └── index.ts
+│   ├── migrations/               # ✅ Create files, ⚠️ needs apply via Lovable
 │   │   └── YYYYMMDDHHMMSS_*.sql
 │   └── config.toml               # ⚠️ Lovable Cloud manages
 ├── .env                          # Local only - Lovable ignores

--- a/plugins/lovable/skills/lovable/references/CLAUDE-template.md
+++ b/plugins/lovable/skills/lovable/references/CLAUDE-template.md
@@ -10,11 +10,13 @@
 - **GitHub**: [GITHUB_URL]
 - **Backend**: [Lovable Cloud / Own Supabase]
 - **Supabase Ref**: [SUPABASE_REF] (if own Supabase)
+- **Architecture**: [Vite SPA (CSR) / TanStack Start (SSR)]
 
 ## Project Structure Map
 
 > Quick navigation guide - run `/lovable:map --update` to refresh
 
+<!-- FOR VITE SPA PROJECTS (vite.config.ts): use this layout -->
 ### Directory Layout
 ```
 src/
@@ -28,7 +30,7 @@ src/
 [ADDITIONAL_DIRS]
 
 supabase/
-├── functions/     # Edge Functions ([FUNCTION_COUNT] functions)
+├── functions/     # Supabase Edge Functions ([FUNCTION_COUNT]) — needs deploy
 └── migrations/    # Database migrations ([MIGRATION_COUNT] migrations)
 ```
 
@@ -52,7 +54,58 @@ supabase/
 | Page routes | `src/pages/` or `src/App.tsx` |
 | API calls | `src/hooks/` or `src/integrations/` |
 | Types | `src/integrations/supabase/types.ts` |
-| Edge functions | `supabase/functions/[name]/index.ts` |
+| Supabase Edge functions | `supabase/functions/[name]/index.ts` |
+
+<!-- FOR TANSTACK START PROJECTS (app.config.ts): replace above with this layout -->
+<!--
+### Directory Layout
+```
+app/
+├── routes/        # File-based routes ([ROUTE_COUNT] routes)
+│   ├── __root.tsx # Root layout
+│   └── *.tsx      # Page routes (filename = URL path)
+├── components/    # [COMPONENT_PATTERN] ([COMPONENT_COUNT] components)
+│   └── ui/        # shadcn/ui primitives
+├── lib/           # Utilities and helpers
+├── integrations/  # External integrations
+│   └── supabase/  # Supabase client and generated types
+[ADDITIONAL_DIRS]
+
+supabase/
+├── functions/     # Supabase Edge Functions ([FUNCTION_COUNT]) — needs deploy
+└── migrations/    # Database migrations ([MIGRATION_COUNT] migrations)
+```
+
+### Key Files
+| File | Purpose |
+|------|---------|
+| `app/routes/__root.tsx` | Root layout (wraps all pages) |
+| `app/routes/index.tsx` | Home page (/) |
+| `app/lib/utils.ts` | Shared utilities |
+| `app/integrations/supabase/client.ts` | Supabase client |
+| `app.config.ts` | TanStack Start configuration |
+[ADDITIONAL_KEY_FILES]
+
+### Patterns
+- **Architecture**: SSR — HTML rendered server-side before browser
+- **Routing**: File-based (app/routes/*.tsx = URL routes)
+- **Server functions**: *.server.ts files auto-deploy — no Lovable prompt needed
+- **Components**: [COMPONENT_PATTERN_DESC]
+- **State**: [STATE_MANAGEMENT]
+- **Data Flow**: Routes (loaders) → Supabase Client → Edge Functions
+
+### Quick Lookup
+| Looking for... | Check here |
+|----------------|------------|
+| UI components | `app/components/ui/` |
+| Page routes | `app/routes/` (file = route) |
+| Root layout | `app/routes/__root.tsx` |
+| Server functions | `app/**/*.server.ts` (auto-deploy) |
+| API calls | `app/lib/` or `app/integrations/` |
+| Types | `app/integrations/supabase/types.ts` |
+| Supabase Edge functions | `supabase/functions/[name]/index.ts` |
+```
+-->
 
 *Map generated: [MAP_TIMESTAMP]*
 
@@ -89,9 +142,10 @@ Changes live in Lovable
 
 ## Workflow Rules
 
+<!-- If Architecture: Vite SPA, use these rules -->
 ### ✅ Safe to edit and push to `main`:
 - All files in `src/` (components, pages, hooks, utils)
-- Config files (vite.config.ts, tailwind.config.js)
+- Config files (`vite.config.ts`, `tailwind.config.js`)
 - Package.json dependencies
 - Edge Function **code** in `supabase/functions/`
 - Migration **files** in `supabase/migrations/`
@@ -105,7 +159,32 @@ Changes live in Lovable
 - Set up RLS policies
 - Add secrets (Cloud → Secrets UI)
 - Create storage buckets
-- Deploy Edge Functions
+- Deploy Supabase Edge Functions
+
+<!-- If Architecture: TanStack Start, replace the above with:
+
+### ✅ Safe to edit and push to `main`:
+- All files in `app/` (routes, components, lib, integrations)
+- TanStack server functions (`app/**/*.server.ts`) — auto-deploy via GitHub, no prompt needed
+- Config files (`app.config.ts`, `tailwind.config.js`)
+- Package.json dependencies
+- Supabase Edge Function **code** in `supabase/functions/`
+- Migration **files** in `supabase/migrations/`
+
+### ⚠️ After editing, provide Lovable prompt:
+- **Supabase Edge Functions**: `"Deploy the [name] edge function"`
+- **Migrations**: `"Apply pending Supabase migrations"`
+
+> Note: TanStack server functions (`*.server.ts` in `app/`) are NOT Supabase Edge Functions.
+> They deploy automatically with the rest of your app — no Lovable prompt needed.
+
+### ❌ Must go through Lovable:
+- Create/modify database tables
+- Set up RLS policies
+- Add secrets (Cloud → Secrets UI)
+- Create storage buckets
+- Deploy Supabase Edge Functions
+-->
 
 ## Secrets
 

--- a/plugins/lovable/skills/lovable/references/codebase-map.md
+++ b/plugins/lovable/skills/lovable/references/codebase-map.md
@@ -16,7 +16,20 @@ Target: ~60 lines, optimized for token efficiency while remaining useful.
 
 ## Scanning Algorithm
 
+### Step 0: Detect Project Architecture
+
+Before scanning, identify which architecture the project uses:
+
+| Check | Result |
+|-------|--------|
+| `app.config.ts` exists at root | **TanStack Start** (new, SSR) |
+| `vite.config.ts` exists at root | **Vite SPA** (legacy, CSR) |
+
+Record the architecture type — it affects which directories to scan and what to document.
+
 ### Step 1: Scan Directory Structure
+
+#### Vite SPA Projects (`vite.config.ts`)
 
 Scan these directories in order:
 
@@ -36,12 +49,39 @@ Scan these directories in order:
    └── assets/             # Static assets
 
 2. supabase/               # Backend
-   ├── functions/          # Edge Functions
+   ├── functions/          # Supabase Edge Functions
    └── migrations/         # Database migrations
 
 3. public/                 # Static files
 
-4. Root config files       # vite.config, tailwind.config, etc.
+4. Root config files       # vite.config.ts, tailwind.config, etc.
+```
+
+#### TanStack Start Projects (`app.config.ts`)
+
+Scan these directories in order:
+
+```
+1. app/                    # Main source code (replaces src/)
+   ├── routes/             # File-based route pages
+   ├── components/         # UI components
+   ├── lib/                # Utilities and helpers
+   ├── utils/              # Alternative utilities location
+   ├── services/           # API services
+   ├── contexts/           # React contexts
+   ├── stores/             # State management
+   ├── types/              # TypeScript definitions
+   ├── integrations/       # External service integrations
+   │   └── supabase/       # Supabase client and types
+   └── *.server.ts         # TanStack server functions (auto-deploy)
+
+2. supabase/               # Backend
+   ├── functions/          # Supabase Edge Functions (need deployment)
+   └── migrations/         # Database migrations
+
+3. public/                 # Static files
+
+4. Root config files       # app.config.ts, tailwind.config, etc.
 ```
 
 ### Step 2: Detect Component Organization Pattern
@@ -79,7 +119,9 @@ components/
 
 ### Step 3: Identify Key Files
 
-Scan for these important files:
+Scan for these important files based on architecture:
+
+#### Vite SPA Key Files
 
 | Pattern | Purpose |
 |---------|---------|
@@ -96,17 +138,35 @@ Scan for these important files:
 | `tailwind.config.js` | Tailwind configuration |
 | `tsconfig.json` | TypeScript configuration |
 
+#### TanStack Start Key Files
+
+| Pattern | Purpose |
+|---------|---------|
+| `app/routes/__root.tsx` | Root layout (wraps all pages) |
+| `app/routes/index.tsx` | Home page (/) |
+| `app/routes/*.tsx` | Route pages (file = route) |
+| `app/lib/utils.ts` | Shared utilities (cn helper) |
+| `app/integrations/supabase/client.ts` | Supabase client |
+| `app/**/*.server.ts` | TanStack server functions (server-only) |
+| `app.config.ts` | TanStack Start configuration |
+| `tailwind.config.js` | Tailwind configuration |
+| `tsconfig.json` | TypeScript configuration |
+
 ### Step 4: Detect Routing Structure
 
-Check for routing patterns:
+Check for routing patterns based on architecture:
 
-**React Router** (check `src/App.tsx` or `src/routes/`):
+**Vite SPA — React Router** (check `src/App.tsx`):
 - Look for `<Routes>`, `<Route>`, `<BrowserRouter>`
 - Extract route paths and their components
 
-**File-based routing** (if using TanStack Router):
-- Check `src/routes/` directory
-- Extract page structure from file names
+**TanStack Start — File-based routing** (check `app/routes/`):
+- Each `.tsx` file in `app/routes/` is a route
+- `__root.tsx` = root layout
+- `index.tsx` = `/`
+- `about.tsx` = `/about`
+- `$id.tsx` = dynamic segment (e.g., `/post/$id`)
+- Nested folders = nested routes
 
 ### Step 5: Detect State Management
 
@@ -136,12 +196,14 @@ Check for:
 
 ## Map Template
 
-Generate this structure (~60 lines):
+Generate this structure (~60 lines). Use the appropriate template based on detected architecture.
+
+### Template: Vite SPA (legacy)
 
 ```markdown
 ## Project Structure Map
 
-> Quick navigation guide - run `/lovable:map --update` to refresh
+> Architecture: Vite SPA (CSR) — Quick navigation guide - run `/lovable:map --update` to refresh
 
 ### Directory Layout
 ```
@@ -156,7 +218,7 @@ src/
 └── [OTHER_DIRS]   # [PURPOSE]
 
 supabase/
-├── functions/     # Edge Functions ([FUNCTION_COUNT] functions)
+├── functions/     # Supabase Edge Functions ([FUNCTION_COUNT] functions) — needs deploy
 └── migrations/    # Database migrations ([MIGRATION_COUNT] migrations)
 ```
 
@@ -181,6 +243,63 @@ supabase/
 | API calls | `src/hooks/` or `src/integrations/` |
 | Types | `src/types/` or `src/integrations/supabase/types.ts` |
 | Edge functions | `supabase/functions/[name]/index.ts` |
+
+*Last updated: [TIMESTAMP]*
+```
+
+### Template: TanStack Start (new)
+
+```markdown
+## Project Structure Map
+
+> Architecture: TanStack Start (SSR) — Quick navigation guide - run `/lovable:map --update` to refresh
+
+### Directory Layout
+```
+app/
+├── routes/        # File-based routes ([ROUTE_COUNT] routes)
+│   ├── __root.tsx # Root layout
+│   └── *.tsx      # Page routes (filename = URL path)
+├── components/    # [COMPONENT_PATTERN] UI components
+│   └── ui/        # shadcn/ui primitives
+├── lib/           # Utilities and helpers
+├── integrations/  # External integrations
+│   └── supabase/  # Supabase client and generated types
+└── [OTHER_DIRS]   # [PURPOSE]
+
+supabase/
+├── functions/     # Supabase Edge Functions ([FUNCTION_COUNT] functions) — needs deploy
+└── migrations/    # Database migrations ([MIGRATION_COUNT] migrations)
+```
+
+### Key Files
+| File | Purpose |
+|------|---------|
+| `app/routes/__root.tsx` | Root layout (wraps all pages) |
+| `app/routes/index.tsx` | Home page (/) |
+| `app/lib/utils.ts` | Shared utilities (cn, formatters) |
+| `app/integrations/supabase/client.ts` | Supabase client configuration |
+| `app.config.ts` | TanStack Start configuration |
+| [OTHER_KEY_FILES] | [PURPOSE] |
+
+### Patterns
+- **Architecture**: SSR — pages render as HTML on the server before browser
+- **Routing**: File-based (app/routes/*.tsx files = URL routes)
+- **Server functions**: `*.server.ts` files auto-deploy via GitHub (no Lovable prompt needed)
+- **Components**: [COMPONENT_PATTERN_DESCRIPTION]
+- **State**: [STATE_MANAGEMENT_PATTERN]
+- **Data Flow**: Routes (loaders) → Supabase Client → Edge Functions
+
+### Quick Lookup
+| Looking for... | Check here |
+|----------------|------------|
+| UI components | `app/components/ui/` |
+| Page routes | `app/routes/` (file = route) |
+| Root layout | `app/routes/__root.tsx` |
+| Server functions | `app/**/*.server.ts` |
+| API calls | `app/lib/` or `app/integrations/` |
+| Types | `app/types/` or `app/integrations/supabase/types.ts` |
+| Supabase Edge functions | `supabase/functions/[name]/index.ts` |
 
 *Last updated: [TIMESTAMP]*
 ```


### PR DESCRIPTION
## Summary

Lovable now ships new projects on **TanStack Start** with full server-side rendering (SSR), file-based routing, and server functions — replacing the legacy Vite SPA stack. This PR makes the plugin aware of both architectures while remaining **fully backward-compatible** with existing Vite SPA projects.

### Key change
TanStack server functions (`app/**/*.server.ts`) auto-deploy via GitHub sync and **do not** need a Lovable deployment prompt — unlike Supabase Edge Functions, which still do. The plugin now distinguishes these clearly so Claude gives correct deployment guidance.

### What changed
- **Architecture auto-detection**: `app.config.ts` (TanStack Start) vs `vite.config.ts` (Vite SPA)
- **`SKILL.md`**: separate sync/deployment rules and file structures per architecture
- **`codebase-map.md`**: Step 0 detection, TanStack scanning, file-based routing, dual map templates
- **`CLAUDE-template.md`**: `Architecture` field + dual structure maps and workflow rules
- **`init-lovable.md`**: architecture-aware scan + generated CLAUDE.md
- **`README.md` / `CHANGELOG.md`**: documented dual-architecture support
- Version bumped to **1.8.1** (`plugin.json`, `marketplace.json`)

### Backward compatibility
No action required for existing users. Vite SPA projects behave identically to v1.8.0.

## Test plan
- [ ] Run `/lovable:init` in a Vite SPA project → confirms `src/`-based rules
- [ ] Run `/lovable:init` in a TanStack Start project → confirms `app/`-based rules + server function note
- [ ] Run `/lovable:map` in both project types → correct template per architecture
- [ ] Verify existing Vite SPA CLAUDE.md files still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)