### PR TITLE
Fix marketplace.json source schema validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "lovable",
-      "source": "plugins/lovable/",
+      "source": "./plugins/lovable",
       "description": "Claude Code integration for Lovable.dev projects. Provides commands, skills, and context for working with Lovable projects via two-way GitHub sync, with integrations with Lovable Cloud's native Edge Functions, database migrations, and backend deployments. Now with Lovable MCP support for faster automated deployments!",
       "version": "1.8.1",
       "author": {


### PR DESCRIPTION
## Problem

Installing the plugin fails with:
```
× Failed to add marketplace: Invalid schema: marketplace.json plugins.0.source: Invalid input
```

The `source` field must start with `./`. An earlier fix (2735bf0) addressed this, but the PR #5 merge reverted it because the feature branch carried the old `"plugins/lovable/"` value.

## Fix

Re-apply `"source": "./plugins/lovable"` so the marketplace passes schema validation.

## Verification

`python3 -m json.tool` confirms valid JSON. After merge, `/plugin marketplace add 10K-Digital/lovable-claude-code` should succeed.